### PR TITLE
Mono

### DIFF
--- a/Services/WCell.RealmServer/Talents/Glyphs.DBC.cs
+++ b/Services/WCell.RealmServer/Talents/Glyphs.DBC.cs
@@ -2,7 +2,6 @@
 using WCell.Constants;
 using WCell.Core;
 using WCell.Core.DBC;
-using NLog;
 
 namespace WCell.RealmServer.Talents
 {


### PR DESCRIPTION
Fix a build mistake because NLog is still being referenced when it is no longer used.
