### PR TITLE
Fixes issue WCell-5

### DIFF
--- a/Services/WCell.RealmServer/Commands/CharacterCommands.cs
+++ b/Services/WCell.RealmServer/Commands/CharacterCommands.cs
@@ -51,7 +51,9 @@ namespace WCell.RealmServer.Commands
 		public override void Process(CmdTrigger<RealmServerCmdArgs> trigger)
 		{
 			var unit = trigger.Args.Target;
-			unit.Level = trigger.Text.NextInt(unit.Level);
+            var level = trigger.Text.NextInt(unit.Level);
+            if (level <= unit.MaxLevel)
+                unit.Level = level;
 		}
 
 		public override ObjectTypeCustom TargetTypes


### PR DESCRIPTION
Only allow levels to be set up to the config max when using the set level command.
